### PR TITLE
Draft: Update for SECURITY_CONTACTS merge into OWNERS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 sudo: false
 go:
-  - 1.11.x
+  - 1.14.x
+env:
+  - GO111MODULE=on
 before_install:
   - go get golang.org/x/lint/golint
   - go get honnef.co/go/tools/cmd/staticcheck

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ go get github.com/jessfraz/secping
 
 ```console
 $ secping -h
-secping -  A tool for reading the SECURITY_CONTACTS file in a kubernetes repository.
+secping -  A tool for reading `security_contacts` in an OWNERS file in a kubernetes repository.
 
 Usage: secping <command>
 

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -30,3 +30,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -26,11 +26,11 @@ type multiString struct {
 	parts []string
 }
 
-type Owners struct {
+type ownersFile struct {
 	SecurityContacts []struct {
-		GitHubId string `yaml:"github"`
+		GitHubID string `yaml:"github"`
 		Email    string `yaml:"email"`
-		SlackId  string `yaml:"slack"`
+		SlackID  string `yaml:"slack"`
 	} `yaml:"security_contacts"`
 }
 
@@ -401,10 +401,10 @@ func (r repoContext) getSecurityContactsForRepo() error {
 	}
 
 	// Parse OWNERS and check that `security_contacts` exists and is not empty
-	owners := Owners{}
+	owners := ownersFile{}
 	err = yaml.Unmarshal([]byte(file), &owners)
 	if err != nil {
-		return fmt.Errorf("Unmarshalling OWNERS failed: %v", err)
+		return fmt.Errorf("unmarshalling OWNERS failed: %v", err)
 	}
 	if len(owners.SecurityContacts) == 0 {
 		// `security_contacts` is empty. We need to check if we already have an existing
@@ -467,17 +467,17 @@ func (r repoContext) getSecurityContactsForRepo() error {
 
 		logrus.WithFields(logrus.Fields{
 			"repo": fmt.Sprintf("%s/%s", r.owner, r.repo),
-		}).Infof("@%s, %s, %s", contact.GitHubId, contact.Email, contact.SlackId)
+		}).Infof("@%s, %s, %s", contact.GitHubID, contact.Email, contact.SlackID)
 
 		if contact.Email == "" {
-			email, err := r.getUserEmail(contact.GitHubId)
+			email, err := r.getUserEmail(contact.GitHubID)
 			if err != nil {
-				return fmt.Errorf("getting user %s's email failed: %v", contact.GitHubId, err)
+				return fmt.Errorf("getting user %s's email failed: %v", contact.GitHubID, err)
 			}
 
 			logrus.WithFields(logrus.Fields{
 				"repo": fmt.Sprintf("%s/%s", r.owner, r.repo),
-			}).Infof("Extra email check for @%s: %s", contact.GitHubId, email)
+			}).Infof("Extra email check for @%s: %s", contact.GitHubID, email)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,6 @@ type ownersFile struct {
 	SecurityContacts []struct {
 		GitHubID string `yaml:"github"`
 		Email    string `yaml:"email"`
-		SlackID  string `yaml:"slack"`
 	} `yaml:"security_contacts"`
 }
 
@@ -467,7 +466,7 @@ func (r repoContext) getSecurityContactsForRepo() error {
 
 		logrus.WithFields(logrus.Fields{
 			"repo": fmt.Sprintf("%s/%s", r.owner, r.repo),
-		}).Infof("@%s, %s, %s", contact.GitHubID, contact.Email, contact.SlackID)
+		}).Infof("@%s, %s", contact.GitHubID, contact.Email)
 
 		if contact.Email == "" {
 			email, err := r.getUserEmail(contact.GitHubID)


### PR DESCRIPTION
Draft to support proposed change here:

https://github.com/kubernetes/security/issues/56
https://github.com/kubernetes/community/pull/5398

We might also want to temporarily disable secping from running in test-infra, during the migration from SECURITY_CONTACTS to OWNERS:

https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml#L333